### PR TITLE
Fix parsing for Hermes Bytecode Version 84

### DIFF
--- a/hbctool/hbc/hbc84/data/opcode.json
+++ b/hbctool/hbc/hbc84/data/opcode.json
@@ -176,14 +176,6 @@
         "Reg8",
         "Reg8"
     ],
-    "Inc": [
-        "Reg8",
-        "Reg8"
-    ],
-    "Dec": [
-        "Reg8",
-        "Reg8"
-    ],
     "InstanceOf": [
         "Reg8",
         "Reg8",

--- a/hbctool/hbc/hbc84/data/structure.json
+++ b/hbctool/hbc/hbc84/data/structure.json
@@ -16,11 +16,12 @@
         "arrayBufferSize": ["uint", 32, 1],
         "objKeyBufferSize": ["uint", 32, 1],
         "objValueBufferSize": ["uint", 32, 1],
-        "cjsModuleOffset": ["uint", 32, 1],
+        "segmentID": ["uint", 32, 1],
         "cjsModuleCount": ["uint", 32, 1],
+        "functionSourceCount": ["uint", 32, 1],
         "debugInfoOffset": ["uint", 32, 1],
         "option": ["uint", 8, 1],
-        "padding": ["uint", 8, 31]
+        "padding": ["uint", 8, 27]
     },
     "SmallFuncHeader": {
         "offset": ["bit", 25, 1],
@@ -67,5 +68,9 @@
     "CJSModuleTable": {
         "first": ["uint", 32, 1],
         "second": ["uint", 32, 1]
+    },
+    "FunctionSourceTable": {
+        "funId": ["uint", 32, 1],
+        "stringId": ["uint", 32, 1]
     }
 }

--- a/hbctool/hbc/hbc84/parser.py
+++ b/hbctool/hbc/hbc84/parser.py
@@ -25,6 +25,7 @@ objValueBufferS = structure["ObjValueBuffer"]
 regExpTableEntryS = structure["RegExpTableEntry"]
 regExpStorageS = structure["RegExpStorage"]
 cjsModuleTableS = structure["CJSModuleTable"]
+funSourceTableS = structure["FunctionSourceTable"]
 
 def align(f):
     f.pad(BYTECODE_ALIGNMENT)
@@ -163,11 +164,24 @@ def parse(f):
     obj["cjsModuleTable"] = cjsModuleTable
     align(f)
 
+
+    # Segment 14: FunctionSourceTable
+    # Not doing anything with this data right now; just advancing the file 
+    # pointer
+    
+    funSourceTable = []
+    for _ in range(header["functionSourceCount"]):
+        funSourceEntry = {}
+        for key in funSourceTableS:
+            funSourceEntry[key] = read(f, funSourceTableS[key])
+
+        funSourceTable.append(funSourceEntry)
+    align(f)
+
     obj["instOffset"] = f.tell()
     obj["inst"] = f.readall()
 
     return obj
-
 def export(obj, f):
     # Segment 1: Header
     header = obj["header"]
@@ -279,6 +293,10 @@ def export(obj, f):
             write(f, cjsModuleEntry[key], cjsModuleTableS[key])
         
     align(f)
+
+    # Segment 14: FunctionSourceTable
+    # TODO: Currently FunctionSourceTable data is NOT USED! This will break
+    # assembly if the source HBC file has entries for this table
 
     # Write remaining
     f.writeall(obj["inst"])


### PR DESCRIPTION
* Fixed `hbctool/hbc/hbc84/data/opcode.json`, removing the `Inc` and `Dec` opcodes that were added by commit `bfa2540` (Merge pull request #22 from hugohabicht01/draft/hbc-v85, 2022-10-25) and not applicable to v84

* Fixed `hbctool/hbc/hbc84/data/structure.json` to include `segmentID` and `functionSourceCount` in the `header` structure. Also added the `FunctionSourceTable` description.

* Fixed `hbctool/hbc/hbc84/parser.py` to read the "Function Source Table" data. This data is only read to advance the pointer in the reader... nothing is done with it.